### PR TITLE
Use http2 for Google Calendar API

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -16,6 +16,8 @@ import type {
 import { getGoogleAppKeys } from "./getGoogleAppKeys";
 import { googleCredentialSchema } from "./googleCredentialSchema";
 
+google.options({ http2: true });
+
 interface GoogleCalError extends Error {
   code?: number;
 }


### PR DESCRIPTION
Trying to optimize for performance again and was looking into batch requesting all user availabilities. It seems that the google calendar API NodeJs client doesn't have support for batch requesting. But [this comment](https://github.com/googleapis/google-api-nodejs-client/issues/2375#issuecomment-717470917) basically recommends to use http2. Cannot hurt I think.