### PR TITLE
Performance improvement of main schedule endpoint

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -16,8 +16,6 @@ import type {
 import { getGoogleAppKeys } from "./getGoogleAppKeys";
 import { googleCredentialSchema } from "./googleCredentialSchema";
 
-google.options({ http2: true });
-
 interface GoogleCalError extends Error {
   code?: number;
 }

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -1,10 +1,39 @@
 import { BookingStatus, Credential, SelectedCalendar } from "@prisma/client";
 
 import { getBusyCalendarTimes } from "@calcom/core/CalendarManager";
+import dayjs from "@calcom/dayjs";
 import logger from "@calcom/lib/logger";
 import { performance } from "@calcom/lib/server/perfObserver";
 import prisma from "@calcom/prisma";
 import type { EventBusyDetails } from "@calcom/types/Calendar";
+
+export async function getBufferedBusyTimes(params: {
+  credentials: Credential[];
+  userId: number;
+  eventTypeId?: number;
+  startTime: string;
+  endTime: string;
+  selectedCalendars: SelectedCalendar[];
+  userBufferTime: number;
+  afterEventBuffer?: number;
+}): Promise<EventBusyDetails[]> {
+  const busy = await getBusyTimes({
+    credentials: params.credentials,
+    userId: params.userId,
+    eventTypeId: params.eventTypeId,
+    startTime: params.startTime,
+    endTime: params.endTime,
+    selectedCalendars: params.selectedCalendars,
+  });
+  return busy.map((a) => ({
+    ...a,
+    start: dayjs(a.start).subtract(params.userBufferTime, "minute").toISOString(),
+    end: dayjs(a.end)
+      .add(params.userBufferTime + (params.afterEventBuffer || 0), "minute")
+      .toISOString(),
+    title: a.title,
+  }));
+}
 
 export async function getBusyTimes(params: {
   credentials: Credential[];

--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -3,7 +3,8 @@ import { Logger } from "tslog";
 import { IS_PRODUCTION } from "./constants";
 
 const logger = new Logger({
-  dateTimePattern: "hour:minute:second.millisecond timeZoneName",
+  type: IS_PRODUCTION ? "json" : "pretty",
+  dateTimePattern: "hour:minute:second.millisecond",
   displayFunctionName: false,
   displayFilePath: "hidden",
   dateTimeTimezone: IS_PRODUCTION ? "utc" : Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -1,9 +1,8 @@
 import { SchedulingType } from "@prisma/client";
 import { z } from "zod";
 
-import { getAggregateWorkingHours } from "@calcom/core/getAggregateWorkingHours";
+import { getBufferedBusyTimes } from "@calcom/core/getBusyTimes";
 import type { CurrentSeats } from "@calcom/core/getUserAvailability";
-import { getUserAvailability } from "@calcom/core/getUserAvailability";
 import dayjs, { Dayjs } from "@calcom/dayjs";
 import { getDefaultEvent } from "@calcom/lib/defaultEvents";
 import isTimeOutOfBounds from "@calcom/lib/isOutOfBounds";
@@ -214,38 +213,30 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   if (!startTime.isValid() || !endTime.isValid()) {
     throw new TRPCError({ message: "Invalid time range given.", code: "BAD_REQUEST" });
   }
-  let currentSeats: CurrentSeats | undefined = undefined;
+  const currentSeats: CurrentSeats | undefined = undefined;
 
   /* We get all users working hours and busy slots */
   const usersWorkingHoursAndBusySlots = await Promise.all(
     eventType.users.map(async (currentUser) => {
-      const {
-        busy,
-        workingHours,
-        currentSeats: _currentSeats,
-        timeZone,
-      } = await getUserAvailability(
-        {
-          userId: currentUser.id,
-          username: currentUser.username || "",
-          dateFrom: startTime.format(),
-          dateTo: endTime.format(),
-          eventTypeId: input.eventTypeId,
-          afterEventBuffer: eventType.afterEventBuffer,
-        },
-        { user: currentUser, eventType, currentSeats }
-      );
-      if (!currentSeats && _currentSeats) currentSeats = _currentSeats;
+      const busy = await getBufferedBusyTimes({
+        credentials: currentUser.credentials,
+        userId: currentUser.id,
+        eventTypeId: input.eventTypeId,
+        startTime: startTime.format(),
+        endTime: endTime.format(),
+        selectedCalendars: currentUser.selectedCalendars,
+        userBufferTime: currentUser.bufferTime,
+        afterEventBuffer: eventType.afterEventBuffer,
+      });
 
       return {
-        timeZone,
-        workingHours,
         busy,
         user: currentUser,
       };
     })
   );
-  const workingHours = getAggregateWorkingHours(usersWorkingHoursAndBusySlots, eventType.schedulingType);
+  // standard working hours for all users
+  const workingHours = [{ days: [0, 1, 2, 3, 4, 5, 6], startTime: 420, endTime: 1140 }];
   const computedAvailableSlots: Record<string, Slot[]> = {};
   const availabilityCheckProps = {
     eventLength: eventType.length,
@@ -299,22 +290,9 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       })
     );
 
-    //const timeInWorkingHours = (time: Dayjs, userWorkingHours: WorkingHours[]) => {
-    //return userWorkingHours.some((wh) => {
-    //const startOfAppointment = time.utc();
-    //const workFrom = startOfAppointment.startOf("day").add(wh.startTime, "minute");
-    //const workUntil = startOfAppointment.startOf("day").add(wh.endTime, "minute");
-    //const endOfAppointment = startOfAppointment.add(eventType.length, "minute");
-    //return wh.days.includes(startOfAppointment.day()) &&
-    //startOfAppointment.isBetween(workFrom, workUntil, null, "[]") &&
-    //endOfAppointment.isBetween(workFrom, workUntil, null, "[]");
-    //});
-    //}
-
     const userIsAvailable = (user: typeof eventType.users[number], time: Dayjs) => {
       const schedule = usersWorkingHoursAndBusySlots.find((s) => s.user.id === user.id);
       if (!schedule) return false;
-      //const inWorkingHours = timeInWorkingHours(time, schedule.workingHours);
       return checkIfIsAvailable({ time, ...schedule, ...availabilityCheckProps });
     };
 
@@ -341,7 +319,6 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   logger.debug(
     `checkForAvailability took ${checkForAvailabilityTime}ms and executed ${checkForAvailabilityCount} times`
   );
-  logger.silly(`Available slots: ${JSON.stringify(computedAvailableSlots)}`);
 
   return {
     slots: computedAvailableSlots,


### PR DESCRIPTION
## Context/Change

When getting the slots for the calendar widget half of the time is spent just creating the scaffold based on all team members working hours. With ~20 team members this alone can take around 2 seconds of CPU bound work. Since we basically do not want to use Calcom's working hours anyway we can safely remove this part and gain performance.

I also removed some excessive logging and configured the logger to log as JSON in production environment.