### PR TITLE
Add hidden custom input type

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -649,12 +649,22 @@ const BookingPage = ({
                   .sort((a, b) => a.id - b.id)
                   .map((input) => (
                     <div className="mb-4" key={input.id}>
-                      {input.type !== EventTypeCustomInputType.BOOL && (
-                        <label
-                          htmlFor={"custom_" + input.id}
-                          className="mb-1 block text-sm font-medium text-gray-700 dark:text-white">
-                          {input.label}
-                        </label>
+                      {input.type !== EventTypeCustomInputType.BOOL &&
+                        input.type !== EventTypeCustomInputType.HIDDEN && (
+                          <label
+                            htmlFor={"custom_" + input.id}
+                            className="mb-1 block text-sm font-medium text-gray-700 dark:text-white">
+                            {input.label}
+                          </label>
+                        )}
+                      {input.type === EventTypeCustomInputType.HIDDEN && (
+                        <input
+                          type="hidden"
+                          {...bookingForm.register(`customInputs.${input.id}`, {
+                            required: input.required,
+                          })}
+                          id={"custom_" + input.id}
+                        />
                       )}
                       {input.type === EventTypeCustomInputType.TEXTLONG && (
                         <textarea

--- a/apps/web/components/v2/eventtype/CustomInputTypeForm.tsx
+++ b/apps/web/components/v2/eventtype/CustomInputTypeForm.tsx
@@ -26,6 +26,7 @@ const CustomInputTypeForm: FC<Props> = (props) => {
     { value: EventTypeCustomInputType.TEXTLONG, label: t("multiline_text") },
     { value: EventTypeCustomInputType.NUMBER, label: t("number") },
     { value: EventTypeCustomInputType.BOOL, label: t("checkbox") },
+    { value: EventTypeCustomInputType.HIDDEN, label: t("hidden") },
   ];
   const { selectedCustomInput } = props;
   const defaultValues = selectedCustomInput || { type: inputOptions[0].value };

--- a/apps/web/public/static/locales/de/common.json
+++ b/apps/web/public/static/locales/de/common.json
@@ -155,6 +155,7 @@
   "multiline_text": "Mehrzeiliger Text",
   "number": "Nummer",
   "checkbox": "Checkbox",
+  "hidden": "Unsichtbar",
   "is_required": "Erforderlich",
   "required": "Erforderlich",
   "optional": "Optional",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -155,6 +155,7 @@
   "multiline_text": "Multiline Text",
   "number": "Number",
   "checkbox": "Checkbox",
+  "hidden": "Hidden",
   "is_required": "Is required",
   "required": "Required",
   "optional": "Optional",

--- a/packages/prisma/migrations/20221103115800_add_hidden_custom_input_type/migration.sql
+++ b/packages/prisma/migrations/20221103115800_add_hidden_custom_input_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EventTypeCustomInputType" ADD VALUE 'hidden';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -342,6 +342,7 @@ enum EventTypeCustomInputType {
   TEXTLONG @map("textLong")
   NUMBER   @map("number")
   BOOL     @map("bool")
+  HIDDEN   @map("hidden")
 }
 
 model EventTypeCustomInput {


### PR DESCRIPTION
A hidden custom input makes sense when you want to attach some data to a booking. But you don't want the user to see or be able to edit that data.