### PR TITLE
Performance improvement when calculating slots

### DIFF
--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -3,7 +3,7 @@ import { Logger } from "tslog";
 import { IS_PRODUCTION } from "./constants";
 
 const logger = new Logger({
-  type: IS_PRODUCTION ? "json" : "pretty",
+  type: "pretty",
   dateTimePattern: "hour:minute:second.millisecond",
   displayFunctionName: false,
   displayFilePath: "hidden",

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -180,16 +180,9 @@ function getRegularOrDynamicEventType(
 
 const getMinimumStartTime = (
   desiredStartTime: Dayjs,
-  {
-    periodType,
-    minimumBookingNotice,
-    periodStartDate,
-  }: Pick<EventType, "periodType" | "periodStartDate" | "minimumBookingNotice">
+  { periodType, periodStartDate }: Pick<EventType, "periodType" | "periodStartDate">
 ) => {
-  const absoluteMinimum = dayjs()
-    .utcOffset(desiredStartTime.utcOffset())
-    .startOf("hour")
-    .add(minimumBookingNotice, "minutes");
+  const absoluteMinimum = dayjs().utcOffset(desiredStartTime.utcOffset()).startOf("day");
   if (periodType === PeriodType.RANGE) {
     const minimum = dayjs(periodStartDate).utcOffset(desiredStartTime.utcOffset()).startOf("day");
     if (minimum.isAfter(absoluteMinimum)) {
@@ -251,7 +244,6 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
 
   const minimumStartTime = getMinimumStartTime(startTime, {
     periodType: eventType.periodType,
-    minimumBookingNotice: eventType.minimumBookingNotice,
     periodStartDate: eventType.periodStartDate,
   });
   const maximumEndTime = getMaximumEndTime(endTime, {

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -293,10 +293,12 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   const workingHours = getWorkingHours({}, [
     {
       days: [1, 2, 3, 4, 5, 6],
-      startTime: dayjs().tz("Europe/Berlin", true).hour(8).minute(0).second(0),
-      endTime: dayjs().tz("Europe/Berlin", true).hour(20).minute(0).second(0),
+      startTime: dayjs.tz("2000-01-01 08:00:00", "Europe/Berlin"),
+      endTime: dayjs.tz("2000-01-01 20:00:00", "Europe/Berlin"),
     },
   ]);
+
+  logger.debug("WORKING HOURS: ", workingHours);
   const computedAvailableSlots: Record<string, Slot[]> = {};
   const needAllUsers = !eventType.schedulingType || eventType.schedulingType === SchedulingType.COLLECTIVE;
 

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -340,11 +340,14 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       const availableUsers = eventType.users
         .filter((user) => userIsAvailable(user, time))
         .map((user) => user.username || "");
+
       if (availableUsers.length === 0) {
+        // don't add the slot if no users are available
         return acc;
       }
 
       if (needAllUsers && availableUsers.length !== eventType.users.length) {
+        // don't add the slot if not all users are available and we need all users (collective)
         return acc;
       }
 

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { getBufferedBusyTimes } from "@calcom/core/getBusyTimes";
 import dayjs, { Dayjs } from "@calcom/dayjs";
+import { getWorkingHours } from "@calcom/lib/availability";
 import { getDefaultEvent } from "@calcom/lib/defaultEvents";
 import logger from "@calcom/lib/logger";
 import { performance } from "@calcom/lib/server/perfObserver";
@@ -295,8 +296,15 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       };
     })
   );
-  // standard working hours for all users
-  const workingHours = [{ days: [1, 2, 3, 4, 5, 6], startTime: 420, endTime: 1140 }];
+
+  // standard working hours for all users. Mo-Sa 8-20 Berlin time.
+  const workingHours = getWorkingHours({}, [
+    {
+      days: [1, 2, 3, 4, 5, 6],
+      startTime: dayjs().tz("Europe/Berlin", true).hour(8).minute(0).second(0),
+      endTime: dayjs().tz("Europe/Berlin", true).hour(20).minute(0).second(0),
+    },
+  ]);
   const computedAvailableSlots: Record<string, Slot[]> = {};
   const needAllUsers = !eventType.schedulingType || eventType.schedulingType === SchedulingType.COLLECTIVE;
 


### PR DESCRIPTION
## Context/Change

This greatly improves the performance by limiting the time slots that have to be checked. The calendar widget usually sends a start time that equals the beginning of the month and an end time that equals the end of the month.

- But the start time can be immediately cut to the current time. You can never book a slot that is before now anyway.
- In the case where a booking can only be scheduled until a certain amount of days into the future, the end time can be cut, too.

Example: Today is Nov 9 and the event type is setup to only allow bookings up until 7 days from now. Now instead of having to calculate the slots from Nov 1 until Nov 30, we can immediately limit the range to Nov 9 + 7 days. This is calculating 8 days vs. 30 days.

So instead of calculating all slots first and only then applying the limits setup on the event type, we limit the actual time range before calculating.

On my local machine with an event type that has more than 40 users the response time is down from 4 - 6 seconds to ~1.5 seconds.
