### PR TITLE
Fix calculated duration undefined

### DIFF
--- a/apps/web/components/booking/pages/BookingPage.tsx
+++ b/apps/web/components/booking/pages/BookingPage.tsx
@@ -29,6 +29,7 @@ import {
   useIsBackgroundTransparent,
   useIsEmbed,
 } from "@calcom/embed-core/embed-iframe";
+import { sdkActionManager } from "@calcom/embed-core/embed-iframe";
 import CustomBranding from "@calcom/lib/CustomBranding";
 import classNames from "@calcom/lib/classNames";
 import getStripeAppData from "@calcom/lib/getStripeAppData";
@@ -123,6 +124,15 @@ const BookingPage = ({
 
   const mutation = useMutation(createBooking, {
     onSuccess: async (responseData) => {
+      if (sdkActionManager) {
+        const payload = {
+          date: responseData.startTime.toString(),
+          bookingInfo: responseData,
+          duration,
+          confirmed: !eventType.requiresConfirmation,
+        };
+        sdkActionManager.fire("bookingSuccessful", payload);
+      }
       const { uid, paymentUid } = responseData;
       if (paymentUid) {
         return await router.push(

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -16,7 +16,6 @@ import { getEventTypeAppData } from "@calcom/app-store/utils";
 import { getEventName } from "@calcom/core/event";
 import dayjs, { ConfigType } from "@calcom/dayjs";
 import {
-  sdkActionManager,
   useEmbedNonStylesConfig,
   useIsBackgroundTransparent,
   useIsEmbed,
@@ -226,29 +225,10 @@ export default function Success(props: SuccessProps) {
   }, [telemetry]);
 
   useEffect(() => {
-    if (!calculatedDuration) {
-      return;
-    }
-    const users = eventType.users;
-    if (!sdkActionManager) return;
-    // TODO: We should probably make it consistent with Webhook payload. Some data is not available here, as and when requirement comes we can add
-    sdkActionManager.fire("bookingSuccessful", {
-      eventType,
-      bookingInfo,
-      date: date.toString(),
-      duration: calculatedDuration,
-      organizer: {
-        name: users[0].name || "Nameless",
-        email: users[0].email || "Email-less",
-        timeZone: users[0].timeZone,
-      },
-      confirmed: !needsConfirmation,
-      // TODO: Add payment details
-    });
     setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
     setIs24h(!!getIs24hClockFromLocalStorage());
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventType, needsConfirmation, calculatedDuration]);
+  }, [eventType, needsConfirmation]);
 
   useEffect(() => {
     setCalculatedDuration(

--- a/apps/web/pages/success.tsx
+++ b/apps/web/pages/success.tsx
@@ -226,6 +226,9 @@ export default function Success(props: SuccessProps) {
   }, [telemetry]);
 
   useEffect(() => {
+    if (!calculatedDuration) {
+      return;
+    }
     const users = eventType.users;
     if (!sdkActionManager) return;
     // TODO: We should probably make it consistent with Webhook payload. Some data is not available here, as and when requirement comes we can add
@@ -245,7 +248,7 @@ export default function Success(props: SuccessProps) {
     setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
     setIs24h(!!getIs24hClockFromLocalStorage());
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventType, needsConfirmation]);
+  }, [eventType, needsConfirmation, calculatedDuration]);
 
   useEffect(() => {
     setCalculatedDuration(


### PR DESCRIPTION
## Context/Change

The recent upstream release introduced a bug that causes the successful booking to be confirmed with an `undefined` duration. Not only fixes this the undefined duration. But it also moves the firing of the event to a different place. The event should only fire once and only once the appointment is booked, not when the success page is accessed (in a `useEffect` hook).

## Reference

https://github.com/calcom/cal.com/pull/5660/files#diff-1e9afd5de724161cc0bf80b40ac965e2e18355f836926f06460bd2d992bf1f9cR235