### PR TITLE
Bugfix: Ability to reschedule with different user

### DIFF
--- a/packages/core/EventManager.ts
+++ b/packages/core/EventManager.ts
@@ -24,7 +24,7 @@ import type {
   PartialReference,
 } from "@calcom/types/EventManager";
 
-import { createEvent, updateEvent } from "./CalendarManager";
+import { createEvent, updateEvent, deleteEvent } from "./CalendarManager";
 import { createMeeting, updateMeeting } from "./videoClient";
 
 export const isDedicatedIntegration = (location: string): boolean => {
@@ -240,7 +240,7 @@ export default class EventManager {
     });
 
     const isDedicated = evt.location ? isDedicatedIntegration(evt.location) : null;
-    const results: Array<EventResult<Event>> = [];
+    const results: Array<EventResult<Exclude<Event, AdditionalInformation>>> = [];
     // If and only if event type is a dedicated meeting, update the dedicated video meeting.
     if (isDedicated) {
       const result = await this.updateVideoEvent(evt, booking);
@@ -293,9 +293,30 @@ export default class EventManager {
     // Wait for all deletions to be applied.
     await Promise.all([bookingReferenceDeletes, attendeeDeletes, bookingDeletes]);
 
+    // Very similar to what is done in create(). But a reschedule might update an event or create a new one.
+    const referencesToCreate = results.map((result) => {
+      let eventObj: createdEventSchema | null = null;
+      const createdOrUpdatedEvent =
+        result.createdEvent ??
+        (Array.isArray(result.updatedEvent) ? result.updatedEvent[0] : result.updatedEvent);
+      if (typeof createdOrUpdatedEvent === "string") {
+        eventObj = createdEventSchema.parse(JSON.parse(createdOrUpdatedEvent));
+      }
+
+      return {
+        type: result.type,
+        uid: eventObj ? eventObj.id : createdOrUpdatedEvent?.id?.toString() ?? "",
+        meetingId: eventObj ? eventObj.id : createdOrUpdatedEvent?.id?.toString(),
+        meetingPassword: eventObj ? eventObj.password : createdOrUpdatedEvent?.password,
+        meetingUrl: eventObj ? eventObj.onlineMeetingUrl : createdOrUpdatedEvent?.url,
+        externalCalendarId: evt.destinationCalendar?.externalId,
+        credentialId: evt.destinationCalendar?.credentialId,
+      };
+    });
+
     return {
       results,
-      referencesToCreate: [...booking.references],
+      referencesToCreate,
     };
   }
 
@@ -451,7 +472,36 @@ export default class EventManager {
         credential = this.calendarCredentials.filter(
           (credential) => credential.id === calendarReference?.credentialId
         )[0];
-        result.push(updateEvent(credential, event, bookingRefUid, bookingExternalCalendarId));
+
+        if (credential) {
+          // This means the user has not changed. Update the calendar event!
+          result.push(updateEvent(credential, event, bookingRefUid, bookingExternalCalendarId));
+        } else {
+          // This means the user has changed. Delete the old calendar event and create a new one!
+          credential = this.calendarCredentials.find((c) => c.type.endsWith("_calendar"));
+          if (credential) {
+            try {
+              await deleteEvent(credential, bookingRefUid, event);
+            } catch {
+              console.log("Could not delete event");
+            }
+          }
+          // Assign the new user credential to `credential`
+          credential = await prisma.credential.findUnique({
+            where: {
+              id: calendarReference.credentialId,
+            },
+          });
+          if (credential) {
+            // createEvent expects a CredentialWithAppName
+            credential = getApps([credential])
+              .flatMap((app) => app.credentials.map((creds) => ({ ...creds, appName: app.name })))
+              .find((cred) => cred.type.endsWith("_calendar"));
+            if (credential) {
+              result.push(createEvent(credential, event));
+            }
+          }
+        }
       } else {
         const credentials = this.calendarCredentials.filter(
           (credential) => credential.type === calendarReference?.type

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -609,8 +609,8 @@ async function handler(req: NextApiRequest & { userId?: number | undefined }) {
 
   async function createBooking() {
     if (originalRescheduledBooking) {
-      evt.title = originalRescheduledBooking?.title || evt.title;
-      evt.description = originalRescheduledBooking?.description || evt.additionalNotes;
+      evt.title = evt.title;
+      evt.description = evt.additionalNotes;
       evt.location = originalRescheduledBooking?.location;
     }
 
@@ -813,6 +813,16 @@ async function handler(req: NextApiRequest & { userId?: number | undefined }) {
           metadata.hangoutLink = updatedEvent.hangoutLink;
           metadata.conferenceData = updatedEvent.conferenceData;
           metadata.entryPoints = updatedEvent.entryPoints;
+        }
+        // A reschedule can create a new event if rescheduled with a different user
+        const createdEvent = results[0].createdEvent;
+        if (createdEvent) {
+          metadata.hangoutLink = createdEvent.hangoutLink;
+          metadata.conferenceData = createdEvent.conferenceData;
+          metadata.entryPoints = createdEvent.entryPoints;
+        }
+
+        if (createdEvent || updatedEvent) {
           handleAppsStatus(results, booking);
         }
       }


### PR DESCRIPTION
## Context/Change

Calcom's rescheduling assumes that the new appointment is with the same user the original appointment was done with. But when the user actually changes it blows up. In that case you cannot simply update the Google calendar event. It has to be deleted in the original Google calendar and a new one has to be created in the new Google calendar.

I don't even want to open a PR in the original repo. The fact that this is running live in production and nobody seems to notice or care is just mind boggling. I cannot believe that we are the first to notice this.