### PR TITLE
Fix multiple durations issue

### DIFF
--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -248,6 +248,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     throw new TRPCError({ code: "NOT_FOUND" });
   }
 
+  const eventLength: number = input.duration || eventType.length;
   const timeZone = input.timeZone || "Etc/GMT";
 
   let startTime =
@@ -324,10 +325,10 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     // get slots retrieves the available times for a given day
     const timeSlots = getTimeSlots({
       inviteeDate: currentCheckedTime,
-      eventLength: input.duration || eventType.length,
+      eventLength,
       workingHours,
       minimumBookingNotice: eventType.minimumBookingNotice,
-      frequency: eventType.slotInterval || input.duration || eventType.length,
+      frequency: eventType.slotInterval || eventLength,
     });
 
     const endGetSlots = performance.now();
@@ -341,7 +342,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
       const available = checkIfIsAvailable({
         time,
         busy: schedule.busy,
-        eventLength: eventType.length,
+        eventLength,
       });
       checkForAvailabilityTime += performance.now() - start;
       checkForAvailabilityCount++;


### PR DESCRIPTION
## Context/Change

Fixes a bug where the calendar does not show all available slots when selecting a custom event duration.

Use the `input.duration` when checking if a user is available for a particular slot.

## Reference

https://tourlane.atlassian.net/browse/TRIP-7209