### PR TITLE
Reschedule with same user

### DIFF
--- a/apps/web/components/booking/pages/AvailabilityPage.tsx
+++ b/apps/web/components/booking/pages/AvailabilityPage.tsx
@@ -55,6 +55,7 @@ const useSlots = ({
   timeZone,
   duration,
   useSlotsProxy,
+  rescheduleUid,
 }: {
   eventTypeId: number;
   eventTypeSlug: string;
@@ -66,6 +67,7 @@ const useSlots = ({
   timeZone?: string;
   duration?: string;
   useSlotsProxy: boolean;
+  rescheduleUid?: string;
 }) => {
   const { data, isLoading, isPaused } = trpc.viewer.public.slots.getSchedule.useQuery(
     {
@@ -78,6 +80,7 @@ const useSlots = ({
       endTime: endTime?.toISOString() || "",
       timeZone,
       duration,
+      rescheduleUid,
     },
     { enabled: !!startTime && !!endTime, trpc: { context: { slotsProxyUrl: useSlotsProxy } } }
   );
@@ -103,6 +106,7 @@ const SlotPicker = ({
   seatsPerTimeSlot,
   weekStart = 0,
   ethSignature,
+  rescheduleUid,
 }: {
   eventType: Pick<EventType, "id" | "schedulingType" | "slug" | "length" | "teamId">;
   timeFormat: TimeFormat;
@@ -113,6 +117,7 @@ const SlotPicker = ({
   users: string[];
   weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   ethSignature?: string;
+  rescheduleUid?: string;
 }) => {
   const [selectedDate, setSelectedDate] = useState<Dayjs>();
   const [browsingDate, setBrowsingDate] = useState<Dayjs>();
@@ -157,6 +162,7 @@ const SlotPicker = ({
     timeZone,
     duration,
     useSlotsProxy: useSlotsProxy !== "false",
+    rescheduleUid,
   });
   const { slots: _2, isLoading } = useSlots({
     eventTypeId: eventType.id,
@@ -169,6 +175,7 @@ const SlotPicker = ({
     timeZone,
     duration,
     useSlotsProxy: useSlotsProxy !== "false",
+    rescheduleUid,
   });
 
   const slots = useMemo(() => ({ ..._2, ..._1 }), [_1, _2]);
@@ -461,6 +468,7 @@ const AvailabilityPage = ({ profile, eventType, ...restProps }: Props) => {
                   seatsPerTimeSlot={eventType.seatsPerTimeSlot || undefined}
                   recurringEventCount={recurringEventCount}
                   ethSignature={gateState.rainbowToken}
+                  rescheduleUid={rescheduleUid}
                 />
               </div>
             </div>

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -40,6 +40,8 @@ const getScheduleSchema = z
       .string()
       .optional()
       .transform((val) => val && parseInt(val)),
+    rescheduleUid: z.string().optional(),
+    rescheduleWithSameUser: z.boolean().optional(),
   })
   .refine(
     (data) => !!data.eventTypeId || !!data.usernameList,
@@ -184,6 +186,28 @@ async function getDynamicEventType(ctx: { prisma: typeof prisma }, input: z.infe
   });
 }
 
+function getOriginalBooking(ctx: { prisma: typeof prisma }, input: z.infer<typeof getScheduleSchema>) {
+  if (!input.rescheduleUid) {
+    return null;
+  }
+
+  return ctx.prisma.booking.findUnique({
+    where: {
+      uid: input.rescheduleUid,
+    },
+    select: {
+      uid: true,
+      startTime: true,
+      endTime: true,
+      user: {
+        select: {
+          ...availabilityUserSelect,
+        },
+      },
+    },
+  });
+}
+
 function getRegularOrDynamicEventType(
   ctx: { prisma: typeof prisma },
   input: z.infer<typeof getScheduleSchema>
@@ -239,6 +263,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   }
   const startPrismaEventTypeGet = performance.now();
   const eventType = await getRegularOrDynamicEventType(ctx, input);
+  const originalBooking = await getOriginalBooking(ctx, input);
   const endPrismaEventTypeGet = performance.now();
   logger.debug(
     `Prisma eventType get took ${endPrismaEventTypeGet - startPrismaEventTypeGet}ms for event:${
@@ -282,9 +307,14 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     throw new TRPCError({ message: "Invalid time range given.", code: "BAD_REQUEST" });
   }
 
+  // If rescheduleWithSameUser is `true` and if this is a reschedule, the only available user is the one
+  // the original booking was scheduled for.
+  const users =
+    input.rescheduleWithSameUser && originalBooking?.user ? [originalBooking.user] : eventType.users;
+
   /* We get all users working hours and busy slots */
   const userAvailability = await Promise.all(
-    eventType.users.map(async (currentUser) => {
+    users.map(async (currentUser) => {
       const busy = await getBufferedBusyTimes({
         credentials: currentUser.credentials,
         userId: currentUser.id,
@@ -351,7 +381,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     };
 
     const timeSlotsForDay = timeSlots.reduce((acc, time) => {
-      const availableUsers = eventType.users
+      const availableUsers = users
         .filter((user) => userIsAvailable(user, time))
         .map((user) => user.username || "");
 
@@ -360,7 +390,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
         return acc;
       }
 
-      if (needAllUsers && availableUsers.length !== eventType.users.length) {
+      if (needAllUsers && availableUsers.length !== users.length) {
         // don't add the slot if not all users are available and we need all users (collective)
         return acc;
       }


### PR DESCRIPTION
## Context/Change

If the availability endpoint is called with `rescheduleWithSameUser: true` and if there is a booking found using `rescheduleUid` the endpoint now only returns availabilities for the same user. That means the user of the original booking will be the user of the new rescheduled booking, too.