### PR TITLE
Compact slots for single host events

### DIFF
--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -1,106 +1,100 @@
-import { expect, it } from "@jest/globals";
-import MockDate from "mockdate";
+import { expect, it, describe } from "@jest/globals";
 
 import dayjs from "@calcom/dayjs";
-import getSlots from "@calcom/lib/slots";
+import { getTimeSlotsCompact } from "@calcom/lib/slots";
 
-import { MINUTES_DAY_END, MINUTES_DAY_START } from "@lib/availability";
-
-MockDate.set("2021-06-20T11:59:59Z");
-
-describe("Tests the slot logic", () => {
-  it("can fit 24 hourly slots for an empty day", async () => {
-    // 24h in a day.
-    expect(
-      getSlots({
-        inviteeDate: dayjs.utc().add(1, "day"),
-        frequency: 60,
-        minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
-        eventLength: 60,
-      })
-    ).toHaveLength(24);
+describe("getTimeSlotsCompact", () => {
+  it("should return an empty array if the slotDay is not in the days array", () => {
+    const slotDay = dayjs("2022-02-01");
+    const shiftStart = dayjs("2022-02-01 9:00");
+    const shiftEnd = dayjs("2022-02-01 17:00");
+    const days = [6, 7];
+    const minStartTime = dayjs("2022-02-01 10:00");
+    const eventLength = 30;
+    const busyTimes = [{ startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") }];
+    const result = getTimeSlotsCompact({
+      slotDay,
+      shiftStart,
+      shiftEnd,
+      days,
+      minStartTime,
+      eventLength,
+      busyTimes,
+    });
+    expect(result).toEqual([]);
   });
 
-  // TODO: This test is sound; it should pass!
-  it("only shows future booking slots on the same day", async () => {
-    // The mock date is 1s to midday, so 12 slots should be open given 0 booking notice.
-    expect(
-      getSlots({
-        inviteeDate: dayjs.utc(),
-        frequency: 60,
-        minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
-        eventLength: 60,
-      })
-    ).toHaveLength(12);
-  });
-
-  it("can cut off dates that due to invitee timezone differences fall on the next day", async () => {
-    expect(
-      getSlots({
-        inviteeDate: dayjs().tz("Europe/Amsterdam").startOf("day"), // time translation +01:00
-        frequency: 60,
-        minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: [0],
-            startTime: 23 * 60, // 23h
-            endTime: MINUTES_DAY_END,
-          },
-        ],
-        eventLength: 60,
-      })
-    ).toHaveLength(0);
-  });
-
-  it("can cut off dates that due to invitee timezone differences fall on the previous day", async () => {
-    const workingHours = [
-      {
-        days: [0],
-        startTime: MINUTES_DAY_START,
-        endTime: 1 * 60, // 1h
-      },
+  it("should return time slots that are not blocked by busy times", () => {
+    const slotDay = dayjs("2022-02-01");
+    const shiftStart = dayjs("2022-02-01 9:00");
+    const shiftEnd = dayjs("2022-02-01 17:00");
+    const days = [0, 1, 2, 3, 4, 5, 6];
+    const minStartTime = dayjs("2022-02-01 10:00");
+    const eventLength = 30;
+    const busyTimes = [
+      { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
+      { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
     ];
-    expect(
-      getSlots({
-        inviteeDate: dayjs().tz("Atlantic/Cape_Verde").startOf("day"), // time translation -01:00
-        frequency: 60,
-        minimumBookingNotice: 0,
-        workingHours,
-        eventLength: 60,
-      })
-    ).toHaveLength(0);
+    const result = getTimeSlotsCompact({
+      slotDay,
+      shiftStart,
+      shiftEnd,
+      days,
+      minStartTime,
+      eventLength,
+      busyTimes,
+    });
+    expect(result).toEqual([
+      dayjs("2022-02-01 10:00"),
+      dayjs("2022-02-01 10:30"),
+      dayjs("2022-02-01 12:00"),
+      dayjs("2022-02-01 12:30"),
+      dayjs("2022-02-01 13:00"),
+      dayjs("2022-02-01 13:30"),
+      dayjs("2022-02-01 15:00"),
+      dayjs("2022-02-01 15:30"),
+      dayjs("2022-02-01 16:00"),
+      dayjs("2022-02-01 16:30"),
+    ]);
   });
 
-  it("adds minimum booking notice correctly", async () => {
-    // 24h in a day.
-    expect(
-      getSlots({
-        inviteeDate: dayjs.utc().add(1, "day").startOf("day"),
-        frequency: 60,
-        minimumBookingNotice: 1500,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
-        eventLength: 60,
-      })
-    ).toHaveLength(11);
+  it("should return an empty array if all the slots are blocked by busy times", () => {
+    const slotDay = dayjs("2022-02-01");
+    const shiftStart = dayjs("2022-02-01 9:00");
+    const shiftEnd = dayjs("2022-02-01 17:00");
+    const days = [0, 1, 2, 3, 4, 5, 6];
+    const minStartTime = dayjs("2022-02-01 10:00");
+    const eventLength = 30;
+    const busyTimes = [{ startTime: dayjs("2022-02-01 10:00"), endTime: dayjs("2022-02-01 17:00") }];
+    const result = getTimeSlotsCompact({
+      slotDay,
+      shiftStart,
+      shiftEnd,
+      days,
+      minStartTime,
+      eventLength,
+      busyTimes,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("should return an empty array if the eventLength is not matched with minStartTime", () => {
+    const slotDay = dayjs("2022-02-01");
+    const shiftStart = dayjs("2022-02-01 9:00");
+    const shiftEnd = dayjs("2022-02-01 17:00");
+    const days = [1, 2, 3, 4, 5];
+    const minStartTime = dayjs("2022-02-01 17:35");
+    const eventLength = 60;
+    const busyTimes = [{ startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") }];
+    const result = getTimeSlotsCompact({
+      slotDay,
+      shiftStart,
+      shiftEnd,
+      days,
+      minStartTime,
+      eventLength,
+      busyTimes,
+    });
+    expect(result).toEqual([]);
   });
 });

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -1,9 +1,111 @@
-import { expect, it, describe } from "@jest/globals";
+import { expect, it } from "@jest/globals";
+import MockDate from "mockdate";
 
 import dayjs from "@calcom/dayjs";
-import { getTimeSlotsCompact } from "@calcom/lib/slots";
+import getSlots, { getTimeSlotsCompact } from "@calcom/lib/slots";
 
-describe("getTimeSlotsCompact", () => {
+import { MINUTES_DAY_END, MINUTES_DAY_START } from "@lib/availability";
+
+MockDate.set("2021-06-20T11:59:59Z");
+
+describe("Tests the slot logic", () => {
+  it("can fit 24 hourly slots for an empty day", async () => {
+    // 24h in a day.
+    expect(
+      getSlots({
+        inviteeDate: dayjs.utc().add(1, "day"),
+        frequency: 60,
+        minimumBookingNotice: 0,
+        workingHours: [
+          {
+            days: Array.from(Array(7).keys()),
+            startTime: MINUTES_DAY_START,
+            endTime: MINUTES_DAY_END,
+          },
+        ],
+        eventLength: 60,
+      })
+    ).toHaveLength(24);
+  });
+
+  // TODO: This test is sound; it should pass!
+  it("only shows future booking slots on the same day", async () => {
+    // The mock date is 1s to midday, so 12 slots should be open given 0 booking notice.
+    expect(
+      getSlots({
+        inviteeDate: dayjs.utc(),
+        frequency: 60,
+        minimumBookingNotice: 0,
+        workingHours: [
+          {
+            days: Array.from(Array(7).keys()),
+            startTime: MINUTES_DAY_START,
+            endTime: MINUTES_DAY_END,
+          },
+        ],
+        eventLength: 60,
+      })
+    ).toHaveLength(12);
+  });
+
+  it("can cut off dates that due to invitee timezone differences fall on the next day", async () => {
+    expect(
+      getSlots({
+        inviteeDate: dayjs().tz("Europe/Amsterdam").startOf("day"), // time translation +01:00
+        frequency: 60,
+        minimumBookingNotice: 0,
+        workingHours: [
+          {
+            days: [0],
+            startTime: 23 * 60, // 23h
+            endTime: MINUTES_DAY_END,
+          },
+        ],
+        eventLength: 60,
+      })
+    ).toHaveLength(0);
+  });
+
+  it("can cut off dates that due to invitee timezone differences fall on the previous day", async () => {
+    const workingHours = [
+      {
+        days: [0],
+        startTime: MINUTES_DAY_START,
+        endTime: 1 * 60, // 1h
+      },
+    ];
+    expect(
+      getSlots({
+        inviteeDate: dayjs().tz("Atlantic/Cape_Verde").startOf("day"), // time translation -01:00
+        frequency: 60,
+        minimumBookingNotice: 0,
+        workingHours,
+        eventLength: 60,
+      })
+    ).toHaveLength(0);
+  });
+
+  it("adds minimum booking notice correctly", async () => {
+    // 24h in a day.
+    expect(
+      getSlots({
+        inviteeDate: dayjs.utc().add(1, "day").startOf("day"),
+        frequency: 60,
+        minimumBookingNotice: 1500,
+        workingHours: [
+          {
+            days: Array.from(Array(7).keys()),
+            startTime: MINUTES_DAY_START,
+            endTime: MINUTES_DAY_END,
+          },
+        ],
+        eventLength: 60,
+      })
+    ).toHaveLength(11);
+  });
+});
+
+describe("Tests the compact slot logic", () => {
   it("should return an empty array if the slotDay is not in the days array", () => {
     const slotDay = dayjs("2022-02-01");
     const shiftStart = dayjs("2022-02-01 9:00");

--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -126,17 +126,40 @@ describe("Tests the compact slot logic", () => {
     expect(result).toEqual([]);
   });
 
-  it("should return time slots that are not blocked by busy times", () => {
+  it.each([
+    {
+      busyTimes: [
+        { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
+        { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
+      ],
+      freeSlots: [
+        dayjs("2022-02-01 10:00"),
+        dayjs("2022-02-01 10:30"),
+        dayjs("2022-02-01 12:00"),
+        dayjs("2022-02-01 12:30"),
+        dayjs("2022-02-01 13:00"),
+        dayjs("2022-02-01 13:30"),
+        dayjs("2022-02-01 15:00"),
+        dayjs("2022-02-01 15:30"),
+        dayjs("2022-02-01 16:00"),
+        dayjs("2022-02-01 16:30"),
+      ],
+    },
+    {
+      busyTimes: [
+        { startTime: dayjs("2022-02-01 10:00"), endTime: dayjs("2022-02-01 16:00") },
+        { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
+        { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
+      ],
+      freeSlots: [dayjs("2022-02-01 16:00"), dayjs("2022-02-01 16:30")],
+    },
+  ])("should return time slots that are not blocked by busy times", ({ busyTimes, freeSlots }) => {
     const slotDay = dayjs("2022-02-01");
     const shiftStart = dayjs("2022-02-01 9:00");
     const shiftEnd = dayjs("2022-02-01 17:00");
     const days = [0, 1, 2, 3, 4, 5, 6];
     const minStartTime = dayjs("2022-02-01 10:00");
     const eventLength = 30;
-    const busyTimes = [
-      { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
-      { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
-    ];
     const result = getTimeSlotsCompact({
       slotDay,
       shiftStart,
@@ -146,18 +169,7 @@ describe("Tests the compact slot logic", () => {
       eventLength,
       busyTimes,
     });
-    expect(result).toEqual([
-      dayjs("2022-02-01 10:00"),
-      dayjs("2022-02-01 10:30"),
-      dayjs("2022-02-01 12:00"),
-      dayjs("2022-02-01 12:30"),
-      dayjs("2022-02-01 13:00"),
-      dayjs("2022-02-01 13:30"),
-      dayjs("2022-02-01 15:00"),
-      dayjs("2022-02-01 15:30"),
-      dayjs("2022-02-01 16:00"),
-      dayjs("2022-02-01 16:30"),
-    ]);
+    expect(result).toEqual(freeSlots);
   });
 
   it("should return an empty array if all the slots are blocked by busy times", () => {

--- a/packages/dayjs/index.ts
+++ b/packages/dayjs/index.ts
@@ -28,6 +28,8 @@ import "dayjs/locale/zh-cn";
 import "dayjs/locale/zh-tw";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import isBetween from "dayjs/plugin/isBetween";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isToday from "dayjs/plugin/isToday";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import minmax from "dayjs/plugin/minMax";
@@ -46,6 +48,8 @@ dayjs.extend(timeZone);
 dayjs.extend(toArray);
 dayjs.extend(utc);
 dayjs.extend(minmax);
+dayjs.extend(isSameOrBefore);
+dayjs.extend(isSameOrAfter);
 
 export type Dayjs = dayjs.Dayjs;
 

--- a/packages/lib/logger.ts
+++ b/packages/lib/logger.ts
@@ -3,9 +3,9 @@ import { Logger } from "tslog";
 import { IS_PRODUCTION } from "./constants";
 
 const logger = new Logger({
-  type: "json",
+  type: IS_PRODUCTION ? "json" : "pretty",
   dateTimePattern: "hour:minute:second.millisecond",
-  minLevel: "info",
+  minLevel: IS_PRODUCTION ? "info" : "debug",
   displayFunctionName: false,
   displayFilePath: "hidden",
   dateTimeTimezone: IS_PRODUCTION ? "utc" : Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -112,7 +112,7 @@ function buildSlots({
  *
  * Note that the current implementation of `getSlotsCompact` only really
  * makes sense for events with a single host. We assume that `busyTimes`
- * only contain busy times for a single host.
+ * only contains busy times for a single host.
  **/
 export const getTimeSlotsCompact = ({
   // Day for which slots are being generated

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -111,8 +111,8 @@ function buildSlots({
  * at 09:50 instead of 10:00. The 10 minutes are not lost.
  *
  * Note that the current implementation of `getSlotsCompact` only really
- * makes sense for events with a single invitee. We assume that `busyTimes`
- * only contain busy times for a single invitee.
+ * makes sense for events with a single host. We assume that `busyTimes`
+ * only contain busy times for a single host.
  **/
 export const getTimeSlotsCompact = ({
   // Day for which slots are being generated

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -11,6 +11,17 @@ export type GetSlots = {
   minimumBookingNotice: number;
   eventLength: number;
 };
+
+export type GetSlotsCompact = {
+  slotDay: Dayjs;
+  shiftStart: Dayjs;
+  shiftEnd: Dayjs;
+  days: number[];
+  minStartTime: Dayjs;
+  eventLength: number;
+  busyTimes: { startTime: Dayjs; endTime: Dayjs }[];
+};
+
 export type TimeFrame = { startTime: number; endTime: number };
 
 /**
@@ -88,6 +99,70 @@ function buildSlots({
 
   return slots;
 }
+
+/**
+ * This function returns the slots available for a given day.
+ * `getSlots` does not take busy times into account. This is why
+ * the slots that are not available must be filtered out afterwards.
+ * `getSlotsCompact` takes busy times into account and returns the
+ * slots as compact as possible, trying to avoid gaps between slots
+ * in the calendar. For example, if the user is busy from 9:00 to
+ * 09:50 and the event length is 30 minutes, the next slot will be
+ * at 09:50 instead of 10:00. The 10 minutes are not lost.
+ *
+ * Note that the current implementation of `getSlotsCompact` only really
+ * makes sense for events with a single invitee. We assume that `busyTimes`
+ * only contain busy times for a single invitee.
+ **/
+export const getTimeSlotsCompact = ({
+  // Day for which slots are being generated
+  slotDay,
+  // Start of the shift on that day
+  shiftStart,
+  // End of the shift on that day
+  shiftEnd,
+  // Array of integers. Days of the week that the shift is active: 0 = Sunday, 1 = Monday, etc.
+  days,
+  // Minimum start time of a slot (at least 2 hours from now for example)
+  minStartTime,
+  // Length of the event in minutes
+  eventLength,
+  // Array of busy times ({ startTime, endTime }) for the day
+  busyTimes,
+}: GetSlotsCompact): Dayjs[] => {
+  if (slotDay.isBefore(minStartTime, "day")) {
+    return [];
+  }
+
+  if (!days.includes(slotDay.day())) {
+    return [];
+  }
+
+  const ret = [] as Dayjs[];
+  let slotStartTime = shiftStart;
+  let slotEndTime = slotStartTime.add(eventLength, "minute");
+
+  while (slotEndTime.isSameOrBefore(shiftEnd)) {
+    if (slotStartTime.isSameOrAfter(minStartTime)) {
+      const busyTimeBlockingThisSlot = busyTimes.find((bT) => {
+        return slotStartTime.isBefore(bT.endTime) && slotEndTime.isAfter(bT.startTime);
+      });
+      if (busyTimeBlockingThisSlot) {
+        // This slot is busy, skip it.
+        // Set the next startTime to the end of this busy slot.
+        // The next slot will begin right after it.
+        slotStartTime = busyTimeBlockingThisSlot.endTime;
+        slotEndTime = slotStartTime.add(eventLength, "minute");
+        continue;
+      } else {
+        ret.push(slotStartTime);
+      }
+    }
+    slotStartTime = slotEndTime;
+    slotEndTime = slotStartTime.add(eventLength, "minute");
+  }
+  return ret;
+};
 
 const getSlots = ({
   inviteeDate,

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -333,7 +333,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     })
   );
 
-  const singleInviteeMode = eventType.users.length === 1;
+  const singleInviteeMode = users.length === 1;
   // Collect all busy times in this record.
   const userBusyTimesByDay = {} as Record<string, { startTime: Dayjs; endTime: Dayjs }[]>;
   if (singleInviteeMode) {

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -333,7 +333,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     })
   );
 
-  const singleHostMode = users.length === 1;
+  const singleHostMode = input.eventTypeTeamId === null;
   // Collect all busy times in this record.
   const userBusyTimesByDay = {} as Record<string, { startTime: Dayjs; endTime: Dayjs }[]>;
   if (singleHostMode) {

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -333,13 +333,13 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     })
   );
 
-  const singleInviteeMode = users.length === 1;
+  const singleHostMode = users.length === 1;
   // Collect all busy times in this record.
   const userBusyTimesByDay = {} as Record<string, { startTime: Dayjs; endTime: Dayjs }[]>;
-  if (singleInviteeMode) {
+  if (singleHostMode) {
     // `userAvailability` is only used in singleInviteeMode.
     userAvailability.forEach(({ busy }) => {
-      if (!singleInviteeMode) {
+      if (!singleHostMode) {
         // No need to do this in single user mode
         return;
       }
@@ -380,7 +380,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   do {
     const startGetSlots = performance.now();
     // get slots retrieves the available times for a given day
-    const timeSlots = singleInviteeMode
+    const timeSlots = singleHostMode
       ? getTimeSlotsCompact({
           slotDay: currentCheckedTime,
           shiftStart: currentCheckedTime
@@ -413,7 +413,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     getSlotsCount++;
 
     const userIsAvailable = (user: typeof eventType.users[number], time: Dayjs) => {
-      if (singleInviteeMode) {
+      if (singleHostMode) {
         // If we are in single user mode, there is no need to check for availability.
         // This has already been done in getSlotsCompact.
         return true;

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -337,12 +337,8 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
   // Collect all busy times in this record.
   const userBusyTimesByDay = {} as Record<string, { startTime: Dayjs; endTime: Dayjs }[]>;
   if (singleHostMode) {
-    // `userAvailability` is only used in singleInviteeMode.
+    // `userBusyTimesByDay` is only used in singleHostMode.
     userAvailability.forEach(({ busy }) => {
-      if (!singleHostMode) {
-        // No need to do this in single user mode
-        return;
-      }
       busy.forEach(({ start, end }) => {
         const day = dayjs(start).format("YYYY-MM-DD");
         if (!userBusyTimesByDay[day]) {
@@ -414,8 +410,9 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
 
     const userIsAvailable = (user: typeof eventType.users[number], time: Dayjs) => {
       if (singleHostMode) {
-        // If we are in single user mode, there is no need to check for availability.
-        // This has already been done in getSlotsCompact.
+        // If we are in singleHostMode, there is no need to check for conflicts.
+        // The slots have been generated respecting the host's busy times.
+        // See `getTimeSlotsCompact` above.
         return true;
       }
       const schedule = userAvailability.find((s) => s.user.id === user.id);


### PR DESCRIPTION
## Context/Change

When there is only one host (only one calendar to check for conflicts) we now generate more compact slots and try to minimize empty gaps between blockers and slots. Calcom usually generates all slots first and only then discards all slots that are not available due to blockers in the calendar. For example if the event length is 30 minutes and the host has some blocker until 10:15 then the next possible slot would be 10:30 to 11:00. The time from 10:15 until 10:30 is wasted. With this approach the next slot will start directly after the blocker at 10:15 leading to a more efficient usage of free time.

We only apply the compact slot generation in single host situations. In situations with more hosts (team events) this approach is less desirable and would be more complex to implement. 
