### PR TITLE
Refactor and performance improvement of availability check

### DIFF
--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -110,6 +110,15 @@ function buildSlots({
   return slots;
 }
 
+// Returns true if slot1 overlaps with slot2.
+// Equality of startTime 1 and endTime 2 or endTime 1 and startTime 2 is NOT considered an overlap.
+export function slotsOverlap(
+  slot1: { startTime: Dayjs; endTime: Dayjs },
+  slot2: { startTime: Dayjs; endTime: Dayjs }
+) {
+  return slot1.startTime.isBefore(slot2.endTime) && slot1.endTime.isAfter(slot2.startTime);
+}
+
 /**
  * This function returns the slots available for a given day.
  * `getSlots` does not take busy times into account. This is why
@@ -154,8 +163,8 @@ export const getTimeSlotsCompact = ({
 
   while (slotEndTime.isSameOrBefore(shiftEnd)) {
     if (slotStartTime.isSameOrAfter(minStartTime)) {
-      const busyTimeBlockingThisSlot = busyTimes.find((bT) => {
-        return slotStartTime.isBefore(bT.endTime) && slotEndTime.isAfter(bT.startTime);
+      const busyTimeBlockingThisSlot = busyTimes.find((busyTime) => {
+        return slotsOverlap({ startTime: slotStartTime, endTime: slotEndTime }, busyTime);
       });
       if (busyTimeBlockingThisSlot) {
         // This slot is busy, skip it.


### PR DESCRIPTION
Make `getBufferedBusyTimes` actually return Dayjs instances and not datetime strings. Those values are needed a lot down the line for calculating availability. So returning Dayjs instances removes the need to parse them again and again.

With team events that have many users this code path is executed thousands of time: number of slots * number of busy times actually. This simple change saves up to a second of raw CPU time with a realistic event that has around 20 users.