### PR TITLE
Bugfix: Busy times grouping

### DIFF
--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -315,10 +315,11 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     // `userBusyTimesByDay` is only used in singleHostMode.
     userAvailability.forEach(({ busy }) => {
       busy.forEach(({ start, end }) => {
-        let startTime = start;
-        const endTime = end;
-        while (startTime.isBefore(endTime)) {
-          const day = startTime.format("YYYY-MM-DD");
+        let currentStart = start;
+        while (currentStart.isSameOrBefore(end)) {
+          // busy times can span multiple days, so we need to add them to each day
+          // they cover.
+          const day = currentStart.format("YYYY-MM-DD");
           if (!userBusyTimesByDay[day]) {
             userBusyTimesByDay[day] = [];
           }
@@ -326,7 +327,7 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
             startTime: start.utc(),
             endTime: end.utc(),
           });
-          startTime = startTime.add(1, "day");
+          currentStart = currentStart.add(1, "day");
         }
       });
     });

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -315,14 +315,19 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
     // `userBusyTimesByDay` is only used in singleHostMode.
     userAvailability.forEach(({ busy }) => {
       busy.forEach(({ start, end }) => {
-        const day = start.format("YYYY-MM-DD");
-        if (!userBusyTimesByDay[day]) {
-          userBusyTimesByDay[day] = [];
+        let startTime = start;
+        const endTime = end;
+        while (startTime.isBefore(endTime)) {
+          const day = startTime.format("YYYY-MM-DD");
+          if (!userBusyTimesByDay[day]) {
+            userBusyTimesByDay[day] = [];
+          }
+          userBusyTimesByDay[day].push({
+            startTime: start.utc(),
+            endTime: end.utc(),
+          });
+          startTime = startTime.add(1, "day");
         }
-        userBusyTimesByDay[day].push({
-          startTime: start.utc(),
-          endTime: end.utc(),
-        });
       });
     });
   }


### PR DESCRIPTION
## Context/Change

Fixes a bug where the busy times are not correctly grouped by day. Busy times in a calendar can span multiple days. In this case the busy time must be added to all days it covers.

Ex. start: 2023-01-01Z20:00:00Z end: 2023-02-01Z10:00:00Z

covers two days and thus if you group this by day you have to add it to both 2023-01-01 and 2023-01-02. Otherwise later down in the code path it is assumed that there are no blockers on 2023-01-02.