### PR TITLE
Improve availability endpoint performance

### DIFF
--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -113,7 +113,7 @@ describe("Tests the compact slot logic", () => {
     const days = [6, 7];
     const minStartTime = dayjs("2022-02-01 10:00");
     const eventLength = 30;
-    const busyTimes = [{ startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") }];
+    const busyTimes = [{ start: dayjs("2022-02-01 11:00"), end: dayjs("2022-02-01 12:00") }];
     const result = getTimeSlotsCompact({
       slotDay,
       shiftStart,
@@ -129,8 +129,8 @@ describe("Tests the compact slot logic", () => {
   it.each([
     {
       busyTimes: [
-        { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
-        { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
+        { start: dayjs("2022-02-01 11:00"), end: dayjs("2022-02-01 12:00") },
+        { start: dayjs("2022-02-01 14:00"), end: dayjs("2022-02-01 15:00") },
       ],
       freeSlots: [
         dayjs("2022-02-01 10:00"),
@@ -147,9 +147,9 @@ describe("Tests the compact slot logic", () => {
     },
     {
       busyTimes: [
-        { startTime: dayjs("2022-02-01 10:00"), endTime: dayjs("2022-02-01 16:00") },
-        { startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") },
-        { startTime: dayjs("2022-02-01 14:00"), endTime: dayjs("2022-02-01 15:00") },
+        { start: dayjs("2022-02-01 10:00"), end: dayjs("2022-02-01 16:00") },
+        { start: dayjs("2022-02-01 11:00"), end: dayjs("2022-02-01 12:00") },
+        { start: dayjs("2022-02-01 14:00"), end: dayjs("2022-02-01 15:00") },
       ],
       freeSlots: [dayjs("2022-02-01 16:00"), dayjs("2022-02-01 16:30")],
     },
@@ -179,7 +179,7 @@ describe("Tests the compact slot logic", () => {
     const days = [0, 1, 2, 3, 4, 5, 6];
     const minStartTime = dayjs("2022-02-01 10:00");
     const eventLength = 30;
-    const busyTimes = [{ startTime: dayjs("2022-02-01 10:00"), endTime: dayjs("2022-02-01 17:00") }];
+    const busyTimes = [{ start: dayjs("2022-02-01 10:00"), end: dayjs("2022-02-01 17:00") }];
     const result = getTimeSlotsCompact({
       slotDay,
       shiftStart,
@@ -199,7 +199,7 @@ describe("Tests the compact slot logic", () => {
     const days = [1, 2, 3, 4, 5];
     const minStartTime = dayjs("2022-02-01 17:35");
     const eventLength = 60;
-    const busyTimes = [{ startTime: dayjs("2022-02-01 11:00"), endTime: dayjs("2022-02-01 12:00") }];
+    const busyTimes = [{ start: dayjs("2022-02-01 11:00"), end: dayjs("2022-02-01 12:00") }];
     const result = getTimeSlotsCompact({
       slotDay,
       shiftStart,

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -205,9 +205,7 @@ async function busyTimesFromDb(params: {
         },
         startTime: { gte: new Date(startTime) },
         endTime: { lte: new Date(endTime) },
-        status: {
-          in: [BookingStatus.ACCEPTED],
-        },
+        status: BookingStatus.ACCEPTED,
       },
       select: {
         id: true,

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -1,5 +1,4 @@
 import { BookingStatus, Credential, SelectedCalendar } from "@prisma/client";
-import { google } from "googleapis";
 
 import { getBusyCalendarTimes } from "@calcom/core/CalendarManager";
 import dayjs, { Dayjs } from "@calcom/dayjs";

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -22,29 +22,6 @@ type EventBusyDetailsWithUser = EventBusyDetails & {
   userId: number | null;
 };
 
-// function test() {
-// const scopes = [
-// "https://www.googleapis.com/auth/calendar"
-// ];
-// const auth = new google.auth.GoogleAuth({
-// keyFile: './creds.json',
-// scopes,
-// });
-
-// const calendar = google.calendar({ version: "v3", auth });
-// calendar.freebusy.query(
-// {
-// requestBody: {
-// timeMin: params.startTime,
-// timeMax: params.endTime,
-// items: [{ id: "jakob.pupke@tourlane.com" }]
-// }
-// }
-// ).then((res) => {
-// console.log("RES", JSON.stringify(res.data));
-// });
-// }
-
 type BusyTimesByUserAndDay = Record<number, Record<string, BusyTimes[]>>;
 
 export async function getBusyTimesByUserAndDay(params: {
@@ -99,6 +76,7 @@ export async function getBusyTimesByUserAndDay(params: {
   }, {} as BusyTimesByUserAndDay);
 }
 
+// currently unused. getBusyTimesByUserAndDay is used instead.
 export async function getBufferedBusyTimes(params: {
   credentials: Credential[];
   userId: number;

--- a/packages/core/getBusyTimes.ts
+++ b/packages/core/getBusyTimes.ts
@@ -15,11 +15,11 @@ export type BusyTimes = {
 };
 
 export type BusyTimesWithUser = BusyTimes & {
-  userId?: number;
+  userId: number | null;
 };
 
 type EventBusyDetailsWithUser = EventBusyDetails & {
-  userId?: number;
+  userId: number | null;
 };
 
 // function test() {
@@ -197,7 +197,7 @@ async function busyTimesFromDb(params: {
   endTime: string;
 }): Promise<EventBusyDetailsWithUser[]> {
   const { userIds, startTime, endTime } = params;
-  const busyTimes: EventBusyDetails[] = await prisma.booking
+  return prisma.booking
     .findMany({
       where: {
         userId: {
@@ -225,8 +225,6 @@ async function busyTimesFromDb(params: {
         userId,
       }))
     );
-
-  return busyTimes;
 }
 
 export default getBusyTimes;

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -19,7 +19,7 @@ export type GetSlotsCompact = {
   days: number[];
   minStartTime: Dayjs;
   eventLength: number;
-  busyTimes: { startTime: Dayjs; endTime: Dayjs }[];
+  busyTimes: { start: Dayjs; end: Dayjs }[];
 };
 
 export type TimeFrame = { startTime: number; endTime: number };
@@ -164,13 +164,16 @@ export const getTimeSlotsCompact = ({
   while (slotEndTime.isSameOrBefore(shiftEnd)) {
     if (slotStartTime.isSameOrAfter(minStartTime)) {
       const busyTimeBlockingThisSlot = busyTimes.find((busyTime) => {
-        return slotsOverlap({ startTime: slotStartTime, endTime: slotEndTime }, busyTime);
+        return slotsOverlap(
+          { startTime: slotStartTime, endTime: slotEndTime },
+          { startTime: busyTime.start, endTime: busyTime.end }
+        );
       });
       if (busyTimeBlockingThisSlot) {
         // This slot is busy, skip it.
         // Set the next startTime to the end of this busy slot.
         // The next slot will begin right after it.
-        slotStartTime = busyTimeBlockingThisSlot.endTime;
+        slotStartTime = busyTimeBlockingThisSlot.end;
         slotEndTime = slotStartTime.add(eventLength, "minute");
         continue;
       } else {

--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -69,12 +69,10 @@ const checkIfIsAvailable = ({
 }): boolean => {
   const slotEndTime = time.add(eventLength, "minutes").utc();
   const slotStartTime = time.utc();
+  const slot = { startTime: slotStartTime, endTime: slotEndTime };
 
-  return busy.every((busyTime) => {
-    return !slotsOverlap(
-      { startTime: slotStartTime, endTime: slotEndTime },
-      { startTime: busyTime.start, endTime: busyTime.end }
-    );
+  return !busy.some((busyTime) => {
+    return slotsOverlap(slot, { startTime: busyTime.start, endTime: busyTime.end });
   });
 };
 


### PR DESCRIPTION
## Context/Change

**Three improvements to improve performance of the availability endpoint**

One database database query for scheduled bookings instead of one query for each user.

Micro improvement of `checkIfIsAvailable` by using `some` instead of `every`

The third improvemen actually really makes the difference. Before the busy times were stored in an array of arrays, one element for each user. So for checking if a user is available for a particular slot we had to do two array operations: `find` and `some`. First `find` the user's busy times and then compare the slot against the busy slots (`some`).

```typescript
allBusyTimes.find(e => e.userId === user.id).some(busy => slotsOverlap(slot, busy))
```

This becomes very slow the more slots there are and the more users there are.

Now we have a more efficient data structure that indexes a user's busy times for a particular day.

```typescript
allBusyTimes[userId][slot.day()].some(.........)
```

All pseudo-code.

I tested locally with an event that has 39 users. 1. May to 31. May. The availability check (`userIsAvailable`) alone took ~4 seconds before. Now it dropped to ~0.3 seconds.
