### PR TITLE
[improve][TRIP-10537] Prevent duplicate bookings

### DIFF
--- a/packages/prisma/migrations/20231111144534_add_unique_index_on_booking_user_id_and_start_time/migration.sql
+++ b/packages/prisma/migrations/20231111144534_add_unique_index_on_booking_user_id_and_start_time/migration.sql
@@ -1,0 +1,1 @@
+create unique index idx_userid_starttime on "Booking" ("userId", "startTime") where "userId" is not null and status = 'accepted';

--- a/packages/prisma/migrations/20231111144534_add_unique_index_on_booking_user_id_and_start_time/migration.sql
+++ b/packages/prisma/migrations/20231111144534_add_unique_index_on_booking_user_id_and_start_time/migration.sql
@@ -1,1 +1,1 @@
-create unique index idx_userid_starttime on "Booking" ("userId", "startTime") where "userId" is not null and status = 'accepted';
+create unique index Booking_userId_startTime_idx on "Booking" ("userId", "startTime") where "userId" is not null and status = 'accepted';


### PR DESCRIPTION
## Context/Change

When booking requests come in at the same time there is a race condition where multiple bookings at the same time are created. This happens all the time actually. We do not know why the frontend could send multiple requests at the same time. Might be some bug or in the end it could be a malicious actor.

In order to prevent this we add a unique index on `userId` and `startTime` on the booking table. It only applies to bookings in accepted state. A canceled booking might be at the same time than an accepted booking actually.

## Reference

https://tourlane.atlassian.net/browse/TRIP-10537