### PR TITLE
[fix] Show hidden custom inputs only to authenticated sessions

### DIFF
--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -209,7 +209,7 @@ export default function Success(props: SuccessProps) {
       : "Nameless";
 
   const [is24h, setIs24h] = useState(isBrowserLocale24h());
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
 
   const [date, setDate] = useState(dayjs.utc(props.bookingInfo.startTime));
   const { eventType, bookingInfo } = props;
@@ -495,7 +495,7 @@ export default function Success(props: SuccessProps) {
                         </div>
                       </>
                     )}
-                    {userIsOwner &&
+                    {sessionStatus === "authenticated" &&
                       customInputs &&
                       Object.keys(customInputs).map((key) => {
                         // This breaks if you have two label that are the same.

--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -495,7 +495,8 @@ export default function Success(props: SuccessProps) {
                         </div>
                       </>
                     )}
-                    {customInputs &&
+                    {userIsOwner &&
+                      customInputs &&
                       Object.keys(customInputs).map((key) => {
                         // This breaks if you have two label that are the same.
                         // TODO: Fix this in another PR

--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -501,9 +501,7 @@ export default function Success(props: SuccessProps) {
                         // TODO: Fix this in another PR
                         const customInput = customInputs[key as keyof typeof customInputs];
                         const eventTypeCustomFound = eventType.customInputs?.find((ci) => ci.label === key);
-                        const showHiddenInputs =
-                          eventTypeCustomFound?.type === "HIDDEN" && sessionStatus === "authenticated";
-                        if (!showHiddenInputs) {
+                        if (eventTypeCustomFound?.type === "HIDDEN" && sessionStatus !== "authenticated") {
                           return null;
                         }
                         return (

--- a/apps/web/pages/booking/[uid].tsx
+++ b/apps/web/pages/booking/[uid].tsx
@@ -495,13 +495,17 @@ export default function Success(props: SuccessProps) {
                         </div>
                       </>
                     )}
-                    {sessionStatus === "authenticated" &&
-                      customInputs &&
+                    {customInputs &&
                       Object.keys(customInputs).map((key) => {
                         // This breaks if you have two label that are the same.
                         // TODO: Fix this in another PR
                         const customInput = customInputs[key as keyof typeof customInputs];
                         const eventTypeCustomFound = eventType.customInputs?.find((ci) => ci.label === key);
+                        const showHiddenInputs =
+                          eventTypeCustomFound?.type === "HIDDEN" && sessionStatus === "authenticated";
+                        if (!showHiddenInputs) {
+                          return null;
+                        }
                         return (
                           <>
                             {eventTypeCustomFound?.type === "RADIO" && (


### PR DESCRIPTION
## Context/Change

Show custom inputs only to authenticated users, to prevent this scenario

![Screenshot 2024-06-28 at 14 00 34](https://github.com/tourlane/cal.com/assets/30813057/b7a0a062-0681-4f2c-98aa-778b838f0922)
