### PR TITLE
[feat] Track user who canceled call

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -255,7 +255,9 @@ async function handler(req: NextApiRequest & { userId?: number }) {
     updatedBookings = updatedBookings.concat(allUpdatedBookings);
   } else {
     const metadata = (bookingToDelete.metadata || {}) as any;
-    metadata["canceledByUser"] = userId;
+    if (userId && userId !== -1) {
+      metadata["canceledByUser"] = userId;
+    }
 
     const updatedBooking = await prisma.booking.update({
       where: {

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -43,6 +43,7 @@ async function handler(req: NextApiRequest & { userId?: number }) {
       ...bookingMinimalSelect,
       recurringEventId: true,
       userId: true,
+      metadata: true,
       user: {
         select: {
           id: true,
@@ -253,6 +254,9 @@ async function handler(req: NextApiRequest & { userId?: number }) {
     });
     updatedBookings = updatedBookings.concat(allUpdatedBookings);
   } else {
+    const metadata = (bookingToDelete.metadata || {}) as any;
+    metadata["canceledByUser"] = userId;
+
     const updatedBooking = await prisma.booking.update({
       where: {
         id,
@@ -261,6 +265,7 @@ async function handler(req: NextApiRequest & { userId?: number }) {
       data: {
         status: BookingStatus.CANCELLED,
         cancellationReason: cancellationReason,
+        metadata: metadata,
       },
       select: {
         startTime: true,


### PR DESCRIPTION
Add the ID of the logged in user if any to the booking metadata when a booking is cancelled. Poor man's audit logging.