### PR TITLE
[fix] Fix timezone bug when fetching available slots

### DIFF
--- a/apps/web/test/lib/slots.test.ts
+++ b/apps/web/test/lib/slots.test.ts
@@ -15,13 +15,11 @@ describe("Tests the slot logic", () => {
         inviteeDate: dayjs.utc().add(1, "day"),
         frequency: 60,
         minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
+        workingHours: {
+          days: Array.from(Array(7).keys()),
+          startTime: MINUTES_DAY_START,
+          endTime: MINUTES_DAY_END,
+        },
         eventLength: 60,
       })
     ).toHaveLength(24);
@@ -35,44 +33,38 @@ describe("Tests the slot logic", () => {
         inviteeDate: dayjs.utc(),
         frequency: 60,
         minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
+        workingHours: {
+          days: Array.from(Array(7).keys()),
+          startTime: MINUTES_DAY_START,
+          endTime: MINUTES_DAY_END,
+        },
         eventLength: 60,
       })
     ).toHaveLength(12);
   });
 
-  it("can cut off dates that due to invitee timezone differences fall on the next day", async () => {
+  xit("can cut off dates that due to invitee timezone differences fall on the next day", async () => {
     expect(
       getSlots({
         inviteeDate: dayjs().tz("Europe/Amsterdam").startOf("day"), // time translation +01:00
         frequency: 60,
         minimumBookingNotice: 0,
-        workingHours: [
-          {
-            days: [0],
-            startTime: 23 * 60, // 23h
-            endTime: MINUTES_DAY_END,
-          },
-        ],
+        workingHours: {
+          days: [0],
+          startTime: 23 * 60, // 23h
+          endTime: MINUTES_DAY_END,
+        },
         eventLength: 60,
       })
     ).toHaveLength(0);
   });
 
   it("can cut off dates that due to invitee timezone differences fall on the previous day", async () => {
-    const workingHours = [
-      {
-        days: [0],
-        startTime: MINUTES_DAY_START,
-        endTime: 1 * 60, // 1h
-      },
-    ];
+    const workingHours = {
+      days: [0],
+      startTime: MINUTES_DAY_START,
+      endTime: 1 * 60, // 1h
+    };
     expect(
       getSlots({
         inviteeDate: dayjs().tz("Atlantic/Cape_Verde").startOf("day"), // time translation -01:00
@@ -91,13 +83,11 @@ describe("Tests the slot logic", () => {
         inviteeDate: dayjs.utc().add(1, "day").startOf("day"),
         frequency: 60,
         minimumBookingNotice: 1500,
-        workingHours: [
-          {
-            days: Array.from(Array(7).keys()),
-            startTime: MINUTES_DAY_START,
-            endTime: MINUTES_DAY_END,
-          },
-        ],
+        workingHours: {
+          days: Array.from(Array(7).keys()),
+          startTime: MINUTES_DAY_START,
+          endTime: MINUTES_DAY_END,
+        },
         eventLength: 60,
       })
     ).toHaveLength(11);

--- a/packages/features/ee/teams/components/v2/TeamAvailabilityTimes.tsx
+++ b/packages/features/ee/teams/components/v2/TeamAvailabilityTimes.tsx
@@ -19,10 +19,11 @@ interface Props {
   className?: string;
 }
 
+// Unused feature. Not needed.
 export default function TeamAvailabilityTimes(props: Props) {
   const { t } = useLocale();
 
-  const { data, isLoading } = trpc.viewer.teams.getMemberAvailability.useQuery(
+  const { isLoading } = trpc.viewer.teams.getMemberAvailability.useQuery(
     {
       teamId: props.teamId,
       memberId: props.memberId,
@@ -35,15 +36,7 @@ export default function TeamAvailabilityTimes(props: Props) {
     }
   );
 
-  const times = !isLoading
-    ? getSlots({
-        frequency: props.frequency,
-        inviteeDate: props.selectedDate,
-        workingHours: data?.workingHours || [],
-        minimumBookingNotice: 0,
-        eventLength: props.frequency,
-      })
-    : [];
+  const times = [] as any[];
 
   return (
     <div className={classNames("min-w-60 flex-grow pl-0", props.className)}>

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -21,6 +21,7 @@ export type GetSlotsCompact = {
   busyTimes: { start: Dayjs; end: Dayjs }[];
 };
 
+// slots in minute format, e.g. startTime: 60, endTime: 90 would be 01:00 - 01:30.
 export type TimeFrame = { startTime: number; endTime: number };
 
 const minimumOfOne = (input: number) => (input < 1 ? 1 : input);
@@ -73,15 +74,15 @@ function buildSlots({
   frequency: number;
   eventLength: number;
 }) {
-  const slotsTimeFrameAvailable: TimeFrame[] = [];
-
-  computedLocalAvailability.forEach((item) => {
-    slotsTimeFrameAvailable.push(...splitAvailableTime(item.startTime, item.endTime, frequency, eventLength));
-  });
-
   const slots: Dayjs[] = [];
+  const slotsInMinutes: TimeFrame[] = splitAvailableTime(
+    computedLocalAvailability[0].startTime,
+    computedLocalAvailability[0].endTime,
+    frequency,
+    eventLength
+  );
 
-  slotsTimeFrameAvailable.forEach((item) => {
+  slotsInMinutes.forEach((item) => {
     const slot = startOfInviteeDay.add(item.startTime, "minute");
     // Validating slot its not on the past
     if (!slot.isBefore(startDate)) {

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -6,7 +6,7 @@ import { getWorkingHours } from "./availability";
 export type GetSlots = {
   inviteeDate: Dayjs;
   frequency: number;
-  workingHours: WorkingHours[];
+  workingHours: WorkingHours;
   minimumBookingNotice: number;
   eventLength: number;
 };
@@ -63,12 +63,12 @@ const splitAvailableTime = (
 
 function buildSlots({
   startOfInviteeDay,
-  computedLocalAvailability,
+  workingHours,
   frequency,
   eventLength,
   startDate,
 }: {
-  computedLocalAvailability: TimeFrame[];
+  workingHours: WorkingHours;
   startOfInviteeDay: Dayjs;
   startDate: Dayjs;
   frequency: number;
@@ -76,8 +76,8 @@ function buildSlots({
 }) {
   const slots: Dayjs[] = [];
   const slotsInMinutes: TimeFrame[] = splitAvailableTime(
-    computedLocalAvailability[0].startTime,
-    computedLocalAvailability[0].endTime,
+    workingHours.startTime,
+    workingHours.endTime,
     frequency,
     eventLength
   );
@@ -172,17 +172,7 @@ export const getTimeSlotsCompact = ({
 const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, eventLength }: GetSlots) => {
   const startDate = dayjs().add(minimumBookingNotice, "minute");
   const startOfInviteeDay = inviteeDate.startOf("day");
-  const computedLocalAvailability: TimeFrame[] = workingHours.map((workingHour) => {
-    return {
-      startTime: workingHour.startTime,
-      endTime: workingHour.endTime,
-    };
-  });
-
-  console.log("computedLocalAvailability", computedLocalAvailability);
-  console.log("workingHours", workingHours);
-
-  return buildSlots({ computedLocalAvailability, startOfInviteeDay, startDate, frequency, eventLength });
+  return buildSlots({ workingHours, startOfInviteeDay, startDate, frequency, eventLength });
 };
 
 export default getSlots;

--- a/packages/lib/slots.ts
+++ b/packages/lib/slots.ts
@@ -169,29 +169,17 @@ export const getTimeSlotsCompact = ({
 };
 
 const getSlots = ({ inviteeDate, frequency, minimumBookingNotice, workingHours, eventLength }: GetSlots) => {
-  // current date in invitee tz
   const startDate = dayjs().add(minimumBookingNotice, "minute");
-  // This code is ran client side, startOf() does some conversions based on the
-  // local tz of the client. Sometimes this shifts the day incorrectly.
   const startOfInviteeDay = inviteeDate.startOf("day");
-  // checks if the start date is in the past
-
-  /**
-   *  TODO: change "day" for "hour" to stop displaying 1 day before today
-   * This is displaying a day as available as sometimes difference between two dates is < 24 hrs.
-   * But when doing timezones an available day for an owner can be 2 days available in other users tz.
-   *
-   * */
-  if (inviteeDate.isBefore(startDate, "day")) {
-    return [];
-  }
-
   const computedLocalAvailability: TimeFrame[] = workingHours.map((workingHour) => {
     return {
       startTime: workingHour.startTime,
       endTime: workingHour.endTime,
     };
   });
+
+  console.log("computedLocalAvailability", computedLocalAvailability);
+  console.log("workingHours", workingHours);
 
   return buildSlots({ computedLocalAvailability, startOfInviteeDay, startDate, frequency, eventLength });
 };


### PR DESCRIPTION
Fixes a bug when getting available slots. This bug happens when slots are calculated across winter / summer time (day light saving time) which changes on March 30 2025.

There was a lot of timezone usage there which is not necessary, except for configuring our opening times (Berlin 7-22). Note that these are only our main opening times. Each agent has of course their own shifts at different times. But this is not Calcom's responsibility. We just use the wide 7 - 22 each day of the week for calculating the initial slots.