### PR TITLE
[feat] Allow string or array of strings for user when booking

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -253,6 +253,7 @@ async function ensureAvailableUsers(
 
     if (isAvailableToBeBooked) {
       availableUsers.push(user);
+      return availableUsers;
     }
   }
   if (!availableUsers.length) {


### PR DESCRIPTION
Allow string or array as string as `user` param but without using this `getGroupName` function which is some unused Calcom feature. Now when we pass an array of string Calcom will find the first available user from the list and assign it to the booking.