### PR TITLE
[improve] Return conflict HTTP status when no user is available

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -257,7 +257,7 @@ async function ensureAvailableUsers(
     }
   }
   if (!availableUsers.length) {
-    throw new Error("No available users found.");
+    throw new HttpError({ statusCode: 409, message: "No available users found." });
   }
   return availableUsers;
 }


### PR DESCRIPTION
Instead of throwing a generic error which results in a 500 error, respond with the appropriate HTTP status.