### PR TITLE
[fix] Fix wrong slots being returned when start time is not beginning of day

### DIFF
--- a/packages/trpc/server/routers/viewer/slots.tsx
+++ b/packages/trpc/server/routers/viewer/slots.tsx
@@ -263,6 +263,8 @@ export async function getSchedule(input: z.infer<typeof getScheduleSchema>, ctx:
 
   let startTime =
     timeZone === "Etc/GMT" ? dayjs.utc(input.startTime) : dayjs(input.startTime).utc().tz(timeZone);
+  // There is a weird bug where wrong availabilities are returned when startTime is e.g. 08:00:00.
+  startTime = startTime.startOf("day");
   let endTime = timeZone === "Etc/GMT" ? dayjs.utc(input.endTime) : dayjs(input.endTime).utc().tz(timeZone);
 
   const minimumStartTime = getMinimumStartTime(timeZone, {


### PR DESCRIPTION
When the start time is e.g. 2025-06-06T08:00:00 Calcom returns completely wrong slots for some reason. This is a quick fix and I don't even want to investigate why since we plan to get rid of Calcom anyway.